### PR TITLE
Touch Portal plugin documentation link changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This Project is an SDK to create a Touch Portal Plugin using Java or Kotlin and Gradle
 
-The Touch Portal Plugin documentation can be found [here](https://www.touch-portal.com/sdk)
+The Touch Portal Plugin documentation can be found [here](https://www.touch-portal.com/api)
 
 ## Documentation
 


### PR DESCRIPTION
the link to the Touch Portal plugin documentation changed from: https://www.touch-portal.com/sdk to: https://www.touch-portal.com/api