### PR TITLE
Use `apple.awt.UIElement` instead of `java.awt.headless` to disable mac dock icon

### DIFF
--- a/AnnotationsProcessor/src/main/java/com/christophecvb/touchportal/annotations/processor/TouchPortalPluginAnnotationProcessor.java
+++ b/AnnotationsProcessor/src/main/java/com/christophecvb/touchportal/annotations/processor/TouchPortalPluginAnnotationProcessor.java
@@ -147,7 +147,7 @@ public class TouchPortalPluginAnnotationProcessor extends AbstractProcessor {
         jsonConfiguration.addProperty(PluginHelper.CONFIGURATION_COLOR_DARK, plugin.colorDark());
         jsonConfiguration.addProperty(PluginHelper.CONFIGURATION_COLOR_LIGHT, plugin.colorLight());
         jsonPlugin.add(PluginHelper.CONFIGURATION, jsonConfiguration);
-        jsonPlugin.addProperty(PluginHelper.PLUGIN_START_COMMAND, "java -Djava.awt.headless=true -jar ./" + pluginElement.getSimpleName() + ".jar " + PluginHelper.COMMAND_START);
+        jsonPlugin.addProperty(PluginHelper.PLUGIN_START_COMMAND, "java -Dapple.awt.UIElement=true -jar ./" + pluginElement.getSimpleName() + ".jar " + PluginHelper.COMMAND_START);
 
         TypeSpec.Builder settingsTypeSpecBuilder = TypeSpec.classBuilder("Settings").addModifiers(Modifier.PUBLIC, Modifier.STATIC);
         JsonArray jsonSettings = new JsonArray();


### PR DESCRIPTION
This is a potentially safer alternative to #43 in that it just changes the property being set.

Pros for this solution:

 * No actual code change!

Cons for this solution:

 * `apple.awt.UIElement` will be set to `true` for every platform, not just mac